### PR TITLE
Fix jsonize docs and tests

### DIFF
--- a/llm_data_cleaner/utils.py
+++ b/llm_data_cleaner/utils.py
@@ -14,7 +14,7 @@ def jsonize(data: Any) -> Any:
       unchanged.
 
     Args:
-        data: The value to normalise.
+        data: The value to normalize.
 
     Returns:
         The JSON string if conversion occurs, otherwise the original value.

--- a/llm_data_cleaner/utils.py
+++ b/llm_data_cleaner/utils.py
@@ -3,20 +3,23 @@ import pandas as pd
 from pydantic import BaseModel, RootModel
 import json
 
-def jsonize(data: Any) -> str:
-    """
-    Convert data to JSON string. Data may be a literal, a list of literals, a BaseModel, or a list of BaseModels. 
-    Dictionaries are not permitted.
-    Use proper JSON parsing, do not manually convert.
+def jsonize(data: Any) -> Any:
+    """Normalize ``data`` for storage.
+
+    - ``BaseModel`` instances and lists of ``BaseModel`` objects are converted to
+      JSON strings.
+    - Lists of primitive values are also JSON encoded so their structure is
+      preserved.
+    - All other values, including dictionaries and integers, are returned
+      unchanged.
 
     Args:
-        data: Data to be converted
+        data: The value to normalise.
 
     Returns:
-        JSON string representation of the data
+        The JSON string if conversion occurs, otherwise the original value.
     """
     if isinstance(data, list):
-        # Check if all elements are BaseModel instances
         if all(isinstance(item, BaseModel) for item in data):
             return json.dumps([item.dict() for item in data], ensure_ascii=False)
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import json
+import pytest
+from pydantic import BaseModel
+from llm_data_cleaner.utils import jsonize
+
+class Dummy(BaseModel):
+    x: int
+
+def test_jsonize_base_model():
+    d = Dummy(x=1)
+    assert jsonize(d) == d.json()
+
+def test_jsonize_list_of_models():
+    d1 = Dummy(x=1)
+    d2 = Dummy(x=2)
+    assert jsonize([d1, d2]) == json.dumps([{"x": 1}, {"x": 2}], ensure_ascii=False)
+
+def test_jsonize_literal():
+    assert jsonize(42) == 42
+    assert jsonize("abc") == "abc"
+
+def test_jsonize_dict_passthrough():
+    assert jsonize({"a": 1}) == {"a": 1}


### PR DESCRIPTION
## Summary
- clarify jsonize docs and return type
- test passthrough for literals and dicts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_utils.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852875b74ec8325a44ae82c97d33ba3